### PR TITLE
QMIT 서버로 전달되는 Keycloak Webhook Uri 를 여러개 지정할 수 있는 기능 추가

### DIFF
--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
@@ -22,6 +22,11 @@ import org.keycloak.Config.Scope;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * @author <a href="mailto:traore_a@outlook.com">Abdoulaye Traore</a>
  */
@@ -43,6 +48,15 @@ public class HTTPEventConfiguration {
 
 		return configuration;
 		
+	}
+
+	private static Set<String> resolveConfigVar(Scope config, String variableName) {
+		String envVariables = System.getenv(PREFIX_CONFIGURATION + variableName.toUpperCase());
+		if (envVariables != null) {
+			return Arrays.stream(envVariables.split(","))
+					.collect(Collectors.toSet());
+		}
+		return Collections.emptySet();
 	}
 	
 	private static String resolveConfigVar(Scope config, String variableName, String defaultValue) {

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
@@ -27,7 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class HTTPEventConfiguration {
 
-    private String serverUri;
+	private static final String PREFIX_CONFIGURATION = "HTTP_EVENT_";
+	private String serverUri;
 	private String username;
 	private String password;
 
@@ -51,7 +52,7 @@ public class HTTPEventConfiguration {
 			value = config.get(variableName);
 		} else {
 			//try from env variables eg: HTTP_EVENT_:
-			String envVariableName = "HTTP_EVENT_" + variableName.toUpperCase();
+			String envVariableName = PREFIX_CONFIGURATION + variableName.toUpperCase();
 			if(System.getenv(envVariableName) != null) {
 				value = System.getenv(envVariableName);
 			}

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 public class HTTPEventConfiguration {
 
 	private static final String PREFIX_CONFIGURATION = "HTTP_EVENT_";
-	private String serverUri;
+	private Set<String> serverUri;
 	private String username;
 	private String password;
 
@@ -42,7 +42,7 @@ public class HTTPEventConfiguration {
 	public static HTTPEventConfiguration createFromScope(Scope config) {
 		HTTPEventConfiguration configuration = new HTTPEventConfiguration();
 		
-		configuration.serverUri = resolveConfigVar(config, "serverUri", "http://127.0.0.1:8080/webhook");
+		configuration.serverUri = resolveConfigVar("serverUri");
 		configuration.username = resolveConfigVar(config, "username", "keycloak");
 		configuration.password = resolveConfigVar(config, "password", "keycloak");
 
@@ -50,7 +50,7 @@ public class HTTPEventConfiguration {
 		
 	}
 
-	private static Set<String> resolveConfigVar(Scope config, String variableName) {
+	private static Set<String> resolveConfigVar(String variableName) {
 		String envVariables = System.getenv(PREFIX_CONFIGURATION + variableName.toUpperCase());
 		if (envVariables != null) {
 			return Arrays.stream(envVariables.split(","))
@@ -94,14 +94,10 @@ public class HTTPEventConfiguration {
 		}
 		return messageAsJson;
 	}
-	
-	
-	
-	public String getServerUri() {
+
+
+	public Set<String> getServerUri() {
 		return serverUri;
-	}
-	public void setServerUri(String serverUri) {
-		this.serverUri = serverUri;
 	}
 
 	public String getUsername() {

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
@@ -46,20 +46,22 @@ public class HTTPEventConfiguration {
 	}
 	
 	private static String resolveConfigVar(Scope config, String variableName, String defaultValue) {
-		
-		String value = defaultValue;
-		if(config != null && config.get(variableName) != null) {
-			value = config.get(variableName);
-		} else {
-			//try from env variables eg: HTTP_EVENT_:
-			String envVariableName = PREFIX_CONFIGURATION + variableName.toUpperCase();
-			if(System.getenv(envVariableName) != null) {
-				value = System.getenv(envVariableName);
-			}
+		String configVariable = resolveConfigVarIfConfigExists(config, variableName);
+		String envVariable = System.getenv(PREFIX_CONFIGURATION + variableName.toUpperCase());
+		if (configVariable != null) {
+			return configVariable;
 		}
-		System.out.println("HTTPEventListener configuration: " + variableName + "=" + value);
-		return value;
-		
+		if (envVariable != null) {
+			return envVariable;
+		}
+		return defaultValue;
+	}
+
+	private static String resolveConfigVarIfConfigExists(Scope config, String variableName) {
+		if (config != null) {
+			return config.get(variableName);
+		}
+		return null;
 	}
 
 	public static String writeAsJson(Object object, boolean isPretty) {

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
@@ -119,7 +119,7 @@ public class HTTPEventListenerProvider implements EventListenerProvider {
                 System.out.println(Objects.requireNonNull(response.body()).string());
             }
         } catch(Exception e) {
-            System.out.println("An error occured while sending event : " + e);
+            System.out.println("An error occured while sending event : " + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
@@ -119,7 +119,7 @@ public class HTTPEventListenerProvider implements EventListenerProvider {
             }
         } catch(Exception e) {
             System.out.println("An error occured while sending event : " + e.getMessage());
-            e.printStackTrace();
+            System.out.println("cause : " + e.getCause());
         }
     }
 

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
@@ -108,8 +108,7 @@ public class HTTPEventListenerProvider implements EventListenerProvider {
                         .post(formBody)
                         .build();
 
-                Response response = httpClient.newCall(request)
-                        .execute();
+                Response response = httpClient.newCall(request).execute();
 
                 if (!response.isSuccessful()) {
                     throw new IOException("Unexpected code " + response);

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
@@ -69,9 +69,8 @@ public class HTTPEventListenerProvider implements EventListenerProvider {
         // Ignore excluded events
         if (excludedEvents != null && excludedEvents.contains(event.getType())) {
             return;
-        } else {
-            tx.addEvent(event);
         }
+        tx.addEvent(event);
     }
 
     @Override
@@ -79,9 +78,8 @@ public class HTTPEventListenerProvider implements EventListenerProvider {
         // Ignore excluded operations
         if (excludedAdminOperations != null && excludedAdminOperations.contains(adminEvent.getOperationType())) {
             return;
-        } else {
-            tx.addAdminEvent(adminEvent, includeRepresentation);
         }
+        tx.addAdminEvent(adminEvent, includeRepresentation);
     }
 
     public void publishEvent(Event event) {

--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProviderFactory.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProviderFactory.java
@@ -35,7 +35,7 @@ public class HTTPEventListenerProviderFactory implements EventListenerProviderFa
 
     private Set<EventType> excludedEvents;
     private Set<OperationType> excludedAdminOperations;
-    private String serverUri;
+    private Set<String> serverUri;
     private String username;
     private String password;
 


### PR DESCRIPTION
## AS-IS

- Keycloak Container 로 전달하는 환경변수 'HTTP_EVENT_SERVERURI' 를 통해 QMIT 서버로 Webhook 을 전송한다

## TO-BE
- 해당 Env 는 하나의 Uri 만 들어가기 때문에 이번 코어 서버 통합에서 자연스럽게 넘어가려면 N개의 Webhook URL 을 가지는 것이 좋다
- Env 에 들어가는 String 값에 "," 가 포함될 경우 리스트로 보고 전체 Webhook 을 전송한다

## Ref
- [참고링크](https://sapalo.dev/2021/06/16/send-keycloak-webhook-events/)
<img width="807" alt="image" src="https://user-images.githubusercontent.com/71342955/209516030-cc9ba19c-f3b4-4ca2-baf8-59af4404ee41.png">


## Notion link
- [티켓](https://www.notion.so/qmit1201/Keycloak-Url-9943cdbdf9fc42949d2d99de30dddfe8)
