### PR TITLE
Webhook 을 호출하는 serverUri 부분 다른 resolve 와 동일하게 config 를 가져오도록 수정

### DIFF
--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventConfiguration.java
@@ -41,8 +41,10 @@ public class HTTPEventConfiguration {
 	
 	public static HTTPEventConfiguration createFromScope(Scope config) {
 		HTTPEventConfiguration configuration = new HTTPEventConfiguration();
-		
-		configuration.serverUri = resolveConfigVar("serverUri");
+
+		String serverUri = resolveConfigVar(config, "serverUri", "http://127.0.0.1:8080/webhook");
+
+		configuration.serverUri = toSet(serverUri, ",");
 		configuration.username = resolveConfigVar(config, "username", "keycloak");
 		configuration.password = resolveConfigVar(config, "password", "keycloak");
 
@@ -50,13 +52,9 @@ public class HTTPEventConfiguration {
 		
 	}
 
-	private static Set<String> resolveConfigVar(String variableName) {
-		String envVariables = System.getenv(PREFIX_CONFIGURATION + variableName.toUpperCase());
-		if (envVariables != null) {
-			return Arrays.stream(envVariables.split(","))
-					.collect(Collectors.toSet());
-		}
-		return Collections.emptySet();
+	private static Set<String> toSet(String envVariables, String regex) {
+		return Arrays.stream(envVariables.split(regex))
+				.collect(Collectors.toSet());
 	}
 	
 	private static String resolveConfigVar(Scope config, String variableName, String defaultValue) {


### PR DESCRIPTION
## AS-IS

- Webhook 호출하는 serverUri 를 가져올 때 Scope.Config 객체에서는 확인하지 않고 넘어간다

## TO-BE

- Webhook 호출하는 serverUri 를 가져올 때 Scope.Config 객체에서도 확인하고 넘어간다

